### PR TITLE
Implements spawn of Energy_Blocks

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -283,6 +283,52 @@ void init_game (){
 }
 
 
+/* Generates energy_block[0] coordinates randomly */
+
+void generate_energy_block()
+{
+    energy_block[0].x = (rand() % (NCOLS - 2)) + 1;
+    energy_block[0].y = (rand() % (NROWS - 2)) + 1;
+}
+
+
+/* Verifies if the block positions conflicts with the snake coordinates */
+
+int energy_block_conflict()
+{
+    int i;
+
+    if(energy_block[0].x == snake.head.x && energy_block[0].y == snake.head.y)
+    {
+        return 1;
+    }
+
+    for(i = 0; i < snake.length - 1; i++)
+    {
+        if(energy_block[0].x == snake.positions[i].x && energy_block[0].y == snake.positions[i].y)
+        {
+           return 1; 
+        }
+    }
+
+    return 0;
+}
+
+
+/* Spawns an energy_block on the map*/
+
+void spawn_energy_block(scene_t* scene)
+{
+    generate_energy_block();
+    
+    while(energy_block_conflict())
+    {
+       generate_energy_block(); 
+    }
+
+    scene[0][energy_block[0].y][energy_block[0].x] = ENERGY_BLOCK;
+}
+
 /* This function moves the snake */
 
 void move_snake(){
@@ -348,7 +394,7 @@ void draw_settings(scene_t *scene){
 /* This function implements the gameplay */
 
 void run(scene_t* scene){
-	int i; 
+	int i;
 	int tail = snake.length - 1;
 	scene[0][snake.positions[tail].y][snake.positions[tail].x] = ' ';
 	move_snake();

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -285,25 +285,6 @@ void init_game (){
 	energy_block[0].y = 27;
 }
 
-/* Checks if the snake has hit itself, a wall or a energy block */
-
-void check_colision(){
-	int i;
-	if(snake.head.x == 0 || snake.head.x == NCOLS - 1){
-		game_end = 1;	
-	} else if(snake.head.y == 0 || snake.head.y == NROWS - 1){
-		game_end = 1;
-	} else if(snake.head.x == energy_block[0].x && snake.head.y == energy_block[0].y){
-		block_count++;
-	}
-	for(i = 0; i < snake.length - 1; i++){
-		if(snake.head.x == snake.positions[i].x && snake.head.y == snake.positions[i].y){
-			game_end = 1;
-			break;
-		}
-	}
-}
-
 /* Generates energy_block[0] coordinates randomly */
 
 void generate_energy_block()
@@ -311,7 +292,6 @@ void generate_energy_block()
     energy_block[0].x = (rand() % (NCOLS - 2)) + 1;
     energy_block[0].y = (rand() % (NROWS - 2)) + 1;
 }
-
 
 /* Verifies if the block positions conflicts with the snake coordinates */
 
@@ -338,7 +318,7 @@ int energy_block_conflict()
 
 /* Spawns an energy_block on the map*/
 
-void spawn_energy_block(scene_t* scene)
+void spawn_energy_block()
 {
     generate_energy_block();
     
@@ -346,9 +326,29 @@ void spawn_energy_block(scene_t* scene)
     {
        generate_energy_block(); 
     }
-
-    scene[0][energy_block[0].y][energy_block[0].x] = ENERGY_BLOCK;
 }
+
+/* Checks if the snake has hit itself, a wall or a energy block */
+
+void check_colision(){
+	int i;
+	if(snake.head.x == 0 || snake.head.x == NCOLS - 1){
+		game_end = 1;	
+	} else if(snake.head.y == 0 || snake.head.y == NROWS - 1){
+		game_end = 1;
+	} else if(snake.head.x == energy_block[0].x && snake.head.y == energy_block[0].y){
+		block_count++;
+		spawn_energy_block();
+	}
+	for(i = 0; i < snake.length - 1; i++){
+		if(snake.head.x == snake.positions[i].x && snake.head.y == snake.positions[i].y){
+			game_end = 1;
+			break;
+		}
+	}
+}
+
+
 
 /* This function moves the snake */
 

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -348,8 +348,6 @@ void check_colision(){
 	}
 }
 
-
-
 /* This function moves the snake */
 
 void move_snake(){


### PR DESCRIPTION
The scheme to implement the spawn of energy blocks consists in a set of
three functions: spawn_energy_block(), generate_energy_block() and
energy_block_conflict().

At first spawn_energy_block() calls function
generate_energy_block() to randomly generate new x and y coordinates to
the energy_block, than it verifies if the new position conflicts with the
snake current positions by calling energy_block_conflict(), if it does,
it calls generate_energy_block() again until energy_block_conflict()
returns false, then it "prints" the ENERGY_BLOCK symbol on the screen.

Fixes #87 .

This PR proposes the following changes:
- Set of three functions to spawn energy blocks.

@mention_to_someone_if_necessary
