### PR TITLE
Improving "--help" text ("--data" description is better now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ If, for some reason, the command returns a message asking for a minimum terminal
  Usage:  ttsnake [options]
 
          Options
-
-         -h, --help      Displays this information message
+		
          -d, --data      Selects a non-default data path to game's assets and "share" folder
-	 	 -v, --version   Outputs the program version
+         -h, --help      Displays this information message
+         -v, --version   Outputs the program version
 ```
 
 ### Playing the game

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ If, for some reason, the command returns a message asking for a minimum terminal
          Options
 
          -h, --help      Displays this information message
-         -d, --data      Selects a non-default data path
-	 -v, --version   Outputs the program version
+         -d, --data      Selects a non-default data path to game's assets and "share" folder
+	 	 -v, --version   Outputs the program version
 ```
 
 ### Playing the game

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -640,29 +640,28 @@ int main(int argc, char **argv)
 
   /* Handles options passed as arguments */
   
-  while ((currOpt = (getopt_long(argc, argv, "d:h:v", stoptions, NULL))) != -1)
-    {
-      switch (currOpt)
-	{
-	case 'd':
-	  /* Changes data_dir to one passed via argument */	  
-	  curr_data_dir = (char *)realloc(curr_data_dir, (strlen(optarg) + 1) * sizeof(char));
-	  strcpy(curr_data_dir, optarg);
-	  break;
-	case 'h':
-	  free(curr_data_dir);
-	  show_help(false);
-	  break;
+  while ((currOpt = (getopt_long(argc, argv, "d:h:v", stoptions, NULL))) != -1) {
+    switch (currOpt) {
+      case 'd':
+        /* Changes data_dir to one passed via argument */	  
+        curr_data_dir = (char *)realloc(curr_data_dir, (strlen(optarg) + 1) * sizeof(char));
+        strcpy(curr_data_dir, optarg);
+        break;
+      
+      case 'h':
+        show_help(false, curr_data_dir);
+        free(curr_data_dir);
+        break;
+        
+      case 'v':
+        free(curr_data_dir);
+        printf (PACKAGE_STRING "\n");
+        exit (EXIT_SUCCESS);
+        break;
 	  
-	case 'v':
-	  free(curr_data_dir);
-	  printf (PACKAGE_STRING "\n");
-	  exit (EXIT_SUCCESS);
-	  break;
-	  
-	default:
-	  free(curr_data_dir);
-	  show_help(true);
+      default:
+        show_help(true, curr_data_dir);
+        free(curr_data_dir);
 	}
       }
   

--- a/src/utils.c
+++ b/src/utils.c
@@ -72,13 +72,14 @@ timeval_add (struct timeval *result, struct timeval *x, struct timeval *y)
 
 /* Shows help screen. Exit code is -1 if isError is set to true */
 
-void show_help(char isError) {
+void show_help(char isError, char * curr_data_dir) {
 
-    fprintf(isError? stderr : stdout, "\
+    fprintf(isError ? stderr : stdout, "\
 Usage: " BIN_NAME " [options]\n\n\
   Options\n\n\
+  -d, --data       Selects a non-default data path to game's assets and \"share\" folder\n\
+                   (default: %s).\n\
   -h, --help       Display this information message.\n\
-  -d, --data       Selects a non-default data path\n\
-  -v, --version    Outputs the program version\n") ;
+  -v, --version    Outputs the program version.\n", curr_data_dir);
     exit(isError?-1:0) ;
 } 

--- a/src/utils.h
+++ b/src/utils.h
@@ -49,6 +49,6 @@ timeval_add (struct timeval *result, struct timeval *x, struct timeval *y);
 
 /* Shows help screen. Exit code is -1 if isError is set to true */
 
-void show_help(char isError);
+void show_help(char isError, char * curr_data_dir);
 
 #endif /* UTILS_H */


### PR DESCRIPTION
Fixes #77 .

This PR proposes the following changes:
- Improving the "--help" text. "--data" description continues simple, but more descriptive;
- Changing order of [options] avaliable to run ttsnake (alphabetical order).

Very simple changes, but even I didn't understand at first glance what "--data" was used for.