### PR TITLE
Fix blank border in the play scene

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -316,8 +316,8 @@ void init_game () {
 	snake.energy = ENERGY_MINIMAL;
 	snake.direction = right;
 	snake.length = 5;
-	snake.head.x = 5;
-	snake.head.y = 5;
+	snake.head.x = 11;
+	snake.head.y = 11;
 
 	snake.positions = (pair_t*) malloc(sizeof(pair_t) * snake.length);
   for (i = 0; i < snake.length; i++) {


### PR DESCRIPTION
Closes #193 

The bug was fixed simply changing the
snake initial position.

Since the border of the game is drawn
only once and at the start of the game,
the blank line between elements of the
body of the snake could erase permanently
parts of the border if at the start the game
snake is close to the border, and his body
passes through the border.

