### PR TITLE
Adding message to inform how to skip cutscene, and changing the key that does that

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ The game score is the count of eaten blocks until the game is over.
 	WASD/HJKL/ARROWS to control the snake
 	+ to increase the game speed
 	- to decrease the game speed
-	Q to quit the game/skip the loading animation
+	Q to quit the game
+	space to skip the loading animation
 	R at game over screen to restart the game
 
 ## Contributing

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -668,7 +668,7 @@ void *userinput () {
                 entered_score = 1;
             }
 
-        }if(go_on_cutscene){ /*if its playing the cutscene*/
+        }else if(go_on_cutscene){ /*if its playing the cutscene*/
             if(c == ' '){
                 kill(mainProcessPid, SIGUSR1);
             }

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -79,6 +79,7 @@ int NCOLS;                /* Number of cols of the game board. */
 int movie_delay;	      /* How long between move scenes. */
 int game_delay;		      /* How long between game scenes. */
 int go_on; 			      /* Whether to continue or to exit main loop.*/
+int go_on_cutscene = 0;   /* Whether to continue to display cutscene or skip it.*/
 int max_energy_blocks;    /* Max number of energy blocks to display at once. */
 
 int block_count; 		      /* Number of energy blocks collected. */
@@ -93,10 +94,16 @@ int actual_pos_nickname = 0;
 
 WINDOW *main_window;
 
+int mainProcessPid; /*Keeps track of main process PID*/
 
 /* SIGINT handler. The variable go_on controls the main loop. */
 void quit () {
     go_on = 0;
+}
+
+/* SIGUSR1 handler. The variable go_on_cutscene controls the cutscene loop. */
+void stop_cutscene () {
+    go_on_cutscene = 0;
 }
 
 
@@ -292,7 +299,7 @@ void showscene (scene_t* scene, int scene_type, int menu) {
         /* Add to the menu score and blocks collected. */
         wprintw(main_window, "Score: %d\n", block_count);
         wprintw(main_window, "Energy: %d\n", snake.energy);
-
+        
         for (i = 0; i < snake.energy; i++) {
             if((MAX_SNAKE_ENERGY / 100) != 0 && i % ((MAX_SNAKE_ENERGY / 100) * 5) == 0) {
                 /* Prints one bar for every 5% energy left. */
@@ -523,10 +530,16 @@ void playmovie (scene_t* scene, int nscenes) {
     struct timespec how_long;
     how_long.tv_sec = 0;
 
-    for (k = 0; (k < nscenes) && go_on; k++) {
+    /*Skip String*/
+    char* skipString = "Press the 'space' key to skip the animation";
+    double halfLen = strlen(skipString)/2.0;
+
+    for (k = 0; (k < nscenes) && go_on_cutscene; k++) {
         wclear(main_window);			               /* Clear screen.    */
         wrefresh(main_window);			               /* Refresh screen.  */
         showscene(scene, k, 0);                  /* Show k-th scene .*/
+        mvwprintw(main_window, NROWS, (int)(NCOLS/2.0-halfLen), skipString); /*Print skip String*/
+        wrefresh(main_window);                          /* Refresh screen.  */
         how_long.tv_nsec = movie_delay*1e3;            /* Compute delay.   */
         nanosleep(&how_long, NULL);	       /* Apply delay.     */
     }
@@ -655,6 +668,10 @@ void *userinput () {
                 entered_score = 1;
             }
 
+        }if(go_on_cutscene){ /*if its playing the cutscene*/
+            if(c == ' '){
+                kill(mainProcessPid, SIGUSR1);
+            }
         } else {
             switch (c) {
                 case 'p':
@@ -699,7 +716,7 @@ void *userinput () {
 
                 case 'q':
                     if (game_end || restarted) {
-                        kill(0, SIGINT);
+                        kill(mainProcessPid, SIGINT);
                     }
                     break;
 
@@ -797,6 +814,11 @@ int main (int argc, char **argv) {
     act.sa_handler = &quit;
     sigaction(SIGINT, &act, NULL);
 
+    /* Handle SIGUSR1(animation control flag). */
+    sigaction(SIGUSR1, NULL, &act);
+    act.sa_handler = &stop_cutscene;
+    sigaction(SIGUSR1, &act, NULL);
+
     /* Ncurses initialization. */
     initscr();
     noecho();
@@ -828,6 +850,8 @@ int main (int argc, char **argv) {
     game_delay  = DEFAULT_GAME_DELAY;	/* Game frame duration in usec (4usec) */
     max_energy_blocks = 3;
 
+
+    mainProcessPid = getpid();
     /* Handle game controls in a different thread. */
     rs = pthread_create(&pthread, NULL, &userinput, NULL);
     sysfatal(rs);
@@ -836,9 +860,9 @@ int main (int argc, char **argv) {
     if(curr_data_dir) {
         nscenes = read_scenes(SCENE_DIR_INTRO, curr_data_dir, &intro_scene,
                             N_INTRO_SCENES);
-        go_on = 1;            /* User may skip intro (q). */
+        go_on_cutscene = 1;            /* User may skip intro (space). */
         playmovie(intro_scene, nscenes);
-
+        go_on_cutscene = 0;
         /* Play game. */
         read_scenes(SCENE_DIR_GAME, curr_data_dir, &game_scene, N_GAME_SCENES);
         go_on = 1;


### PR DESCRIPTION
Fixes #199  .

This PR proposes the following changes:
- Adding the information of how to skip the cutscene during its execution
- Changing the key that skips the cutscene to 'space'
- Fixing some bad code involving signal handling(the interrupt signal was sent to all processes in the group, now it's only sent to the main process)
