### PR TITLE
Fixing memory leaks

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -613,7 +613,7 @@ void playgame (scene_t* scene, char* curr_data_dir) {
         } else if (game_end) {
             showscene(scene, GAME_OVER, 0);
             read_scenes(SCENE_DIR_GAME, curr_data_dir, &scene, N_GAME_SCENES);
-
+        
         } else if (paused) {
             showscene(scene, PAUSED, 1);
 
@@ -727,7 +727,9 @@ void *userinput () {
 
                 case 'q':
                     if (game_end || restarted) {
-                        kill(mainProcessPid, SIGINT);
+                        /* Both flags equals 1 means game is over for real and we should (try to) quit gracefully */
+                        quit();
+                        return NULL; /* Ending thread */
                     }
                     break;
 
@@ -882,6 +884,12 @@ int main (int argc, char **argv) {
         gettimeofday(&beginning, NULL);
         init_game();
         playgame(game_scene, curr_data_dir);
+    }
+
+    /* Waits game control thread to end */
+    int controls_thread_err = pthread_join(pthread, NULL);
+    if (controls_thread_err) {
+        return EXIT_FAILURE;
     }
 
     endwin();

--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -161,7 +161,9 @@ int read_scenes (char *dir, char *data_dir, scene_t** scene, int nscenes) {
     FILE *file;
     char scenefile[1024], c;
 
-    *scene = malloc(sizeof(**scene) * nscenes);
+    /* Same scene is used sometimes. In this case, *scene != NULL and there's no need to malloc again */
+    if (*scene == NULL)
+        *scene = malloc(sizeof(**scene) * nscenes);
 
     /* Read nscenes. */
     for (k = 0; k < nscenes; k++) {


### PR DESCRIPTION
Fixes #151.

This PR proposes the following changes:
- Fixes memory leaks from read_scenes()
- Fixes memory leaks from main()
- Fixes memory leaks from pthread_create()

![image](https://user-images.githubusercontent.com/47257437/148651832-fd3a237c-0da6-4f70-a5dc-aaa6f51ce35e.png)

As mentioned in #183 , I'm not sure if the double free remains here or any other bugs were introduced by the changes I made. 
