### PR TITLE
Solve compiler warnings

### DIFF
--- a/src/score.c
+++ b/src/score.c
@@ -25,6 +25,15 @@
 #include <curses.h>
 #include "score.h"
 
+
+/*  assert if a the file was properly read by fread 
+    fread will return the number of members read, so if it differs from the number
+    of members passed as an argument (3rd argument) something went wrong.
+*/
+#define ASSERT_WHOLE_FILE_READ(file, nmemb) if ((file) != (nmemb)) \
+	fprintf(stderr, "File  \""#file"\" could not be properly read\n");
+
+
 /* Struct used to represent a single score */
 typedef struct {
     char nickname[MAX_NICKNAME + 1]; /* User defined nickname */
@@ -82,8 +91,13 @@ top_scores_t* read_scores(){
     int i;
     /* Run through the scores by reading each player's score */
     for(i = 0; i < nScores; i++) {
-        fread(topScores->scores[i].nickname, sizeof(char), MAX_NICKNAME + 1, fp);
-        fread(&(topScores->scores[i].points), sizeof(int), 1, fp);
+        ASSERT_WHOLE_FILE_READ(
+            fread(topScores->scores[i].nickname, sizeof(char), MAX_NICKNAME + 1, fp),
+            MAX_NICKNAME + 1);
+            
+        ASSERT_WHOLE_FILE_READ(
+            fread(&(topScores->scores[i].points), sizeof(int), 1, fp),
+            1);
     }
 
     fclose(fp); /* Close the file */

--- a/src/score.c
+++ b/src/score.c
@@ -26,12 +26,12 @@
 #include "score.h"
 
 
-/*  assert if a the file was properly read by fread 
+/*  assert if the file was properly read by fread.
     fread will return the number of members read, so if it differs from the number
     of members passed as an argument (3rd argument) something went wrong.
 */
-#define ASSERT_WHOLE_FILE_READ(file, nmemb) if ((file) != (nmemb)) \
-	fprintf(stderr, "File  \""#file"\" could not be properly read\n");
+#define ASSERT_WHOLE_FILE_READ(freadcall, nmemb) if ((freadcall) != (nmemb)) \
+	fprintf(stderr, "File in \""#freadcall"\" could not be properly read\n");
 
 
 /* Struct used to represent a single score */
@@ -94,7 +94,7 @@ top_scores_t* read_scores(){
         ASSERT_WHOLE_FILE_READ(
             fread(topScores->scores[i].nickname, sizeof(char), MAX_NICKNAME + 1, fp),
             MAX_NICKNAME + 1);
-            
+
         ASSERT_WHOLE_FILE_READ(
             fread(&(topScores->scores[i].points), sizeof(int), 1, fp),
             1);


### PR DESCRIPTION
fixes #267.

Solved the compiler warnings using a solution similar to the one used in #253

This PR proposes the following changes:
- add a function-like macro that checks if the entire file was properly read by ```fread``` and print an error message if the call fails.
