### PR TITLE
Argument to start the game without soundtrack

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -94,6 +94,7 @@ int colored_mode = 0;	  /*Whether or not to display the game in colored mode*/
 int selected_option = 0;
 
 
+int run_with_soundtrack = 1;
 int block_count; 		      /* Number of energy blocks collected. */
 
 int paused = 1; 		      /* Play/Pause indicator. */
@@ -467,7 +468,9 @@ void spawn_energy_block () {
 
 /* Initialize resources and counters. */
 void init_game () {
-	ASSERT_SYSTEM_CALL(system("curl https://raw.githubusercontent.com/courselab/snaskii21/develop/sound/maintheme.mp3 | mpg123 --no-visual --no-control --quiet - &"));
+  if (run_with_soundtrack) {
+	  ASSERT_SYSTEM_CALL(system("curl https://raw.githubusercontent.com/courselab/snaskii21/develop/sound/maintheme.mp3 | mpg123 --no-visual --no-control --quiet - &"));
+  }
 
     /* fflush to avoid influence of past key pressed after game is restarted */
     fflush(stdin);
@@ -860,8 +863,14 @@ void *userinput () {
 
 				case 'r':
 					if (game_end) {
-						ASSERT_SYSTEM_CALL(system("killall mpg123"));
-						init_game();
+            /* Check wheter the parameter --no-soundtrack was used
+             * during program execution
+             */
+            if (run_with_soundtrack) {
+              ASSERT_SYSTEM_CALL(system("killall mpg123"));
+            }
+	
+            init_game();
 						restarted = 1;
 						game_end = 0;
 					}
@@ -908,8 +917,9 @@ int main (int argc, char **argv) {
 	const struct option stoptions[] = {
 					 {"data", required_argument, 0, 'd'},
 					 {"help", no_argument, 0, 'h'},
-					 {"version", no_argument, 0, 'v'}};
-
+					 {"version", no_argument, 0, 'v'},
+					 {"no-soundtrack", no_argument, 0, 's'}};
+      
 	/* Defaults curr_data_screen to {datarootdir}/ttsnake */
 	char *curr_data_dir = (char *)malloc((strlen(DATADIR "/" ALT_SHORT_NAME) + 1)
 									   * sizeof(char));
@@ -919,7 +929,7 @@ int main (int argc, char **argv) {
 	char curr_opt;
 
 	/* Handle options passed as arguments. */
-	while ((curr_opt = (getopt_long(argc, argv, "d:h:v", stoptions, NULL))) != -1) {
+	while ((curr_opt = (getopt_long(argc, argv, "d:h:v:s", stoptions, NULL))) != -1) {
 
 		switch (curr_opt) {
 			/* Changes data_dir to one passed via argument. */
@@ -936,6 +946,11 @@ int main (int argc, char **argv) {
 				free(curr_data_dir);
 				printf (PACKAGE_STRING "\n");
 				exit (EXIT_SUCCESS);
+
+      case 's':
+        /* Disable flag that enables soundtrack on initialization */
+        run_with_soundtrack = 0;
+        break;
 
 			default:
 				show_help(true, curr_data_dir);
@@ -992,17 +1007,11 @@ int main (int argc, char **argv) {
 							(max_height - NROWS - LOWER_PANEL_ROWS)/2,
 							(max_width - NCOLS)/2);
 	wrefresh(main_window);
-	
-
-
-
-	
 
 	/* Default values. */
 	movie_delay = 2.5E4;	            /* Movie frame duration in usec (40usec) */
 	game_delay  = DEFAULT_GAME_DELAY;	/* Game frame duration in usec (4usec) */
 	max_energy_blocks = 3;
-
 
 	main_process_pid = getpid();
 	/* Handle game controls in a different thread. */
@@ -1040,6 +1049,12 @@ int main (int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	ASSERT_SYSTEM_CALL(system("killall mpg123"));
+  /* Check wheter the parameter --no-soundtrack was used
+   * during program execution
+   */
+	if (run_with_soundtrack) {
+    ASSERT_SYSTEM_CALL(system("killall mpg123"));
+  }
+
 	return EXIT_SUCCESS;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -78,9 +78,10 @@ void show_help (char isError, char * curr_data_dir) {
   fprintf(isError ? stderr : stdout, "\
 Usage: " BIN_NAME " [options]\n\n\
   Options\n\n\
-  -d, --data       Selects a non-default data path to game's assets and \"share\" folder\n\
-                   (default: %s).\n\
-  -h, --help       Display this information message.\n\
-  -v, --version    Outputs the program version.\n", curr_data_dir);
+  -d, --data                Selects a non-default data path to game's assets and \"share\" folder\n\
+                            (default: %s).\n\
+  -h, --help                Display this information message.\n\
+  -s, --no-soundtrack       Start the game without the initial soundtrack\n\
+  -v, --version             Outputs the program version.\n", curr_data_dir);
   exit(isError ? -1 : 0);
 } 


### PR DESCRIPTION
Fixes #287.

### This PR proposes the following changes:
- Adittion to program parameter with the possibility of starting the game without any soundtrack 
- Update to `show_help()` to display that option

### Tests:
To test whether i succesfully removed the syscall calling `curl` and then `mpg123`, I traced all the syscalls that have been done by the program to make sure that neither `clone` (syscall used by the `system()` command) nor `kill` (syscall used the `killall` command).

Steps:
1) I used the command `strace` to store the syscalls used by the program without any flag.
```
$ strace -f -o syscall_tracer.txt ./src/ttsnake.bin
```

2) I used the command `strace` to store the syscalls used by the program that ran with --no-soundtrack argument (The same thing with -s).
```
$ strace -f -o syscall_tracer_no_soundtrack.txt ./src/ttsnake.bin -s
```

3) Then I grepped for the syscalls that should appear during the regular execution:
```
$ cat syscall_tracer.txt | grep clone 
62857 clone(child_stack=0x7f429193ffb0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID <unfinished ...>
62857 <... clone resumed>, parent_tid=[62858], tls=0x7f4291940700, child_tidptr=0x7f42919409d0) = 62858
62857 clone(child_stack=0x7f4291d26ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD <unfinished ...>
62857 <... clone resumed>)              = 62859
62859 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f514f228850) = 62860
62859 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD <unfinished ...>
62859 <... clone resumed>, child_tidptr=0x7f514f228850) = 62861
62860 clone(child_stack=0x7fe431e7dd70, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[62862], tls=0x7fe431e7e700, child_tidptr=0x7fe431e7e9d0) = 62862
62857 clone(child_stack=0x7f4291d26ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD <unfinished ...>
62857 <... clone resumed>)              = 62873
62873 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f77e9f38850) = 62874

$ cat syscall_tracer.txt | grep kill
62858 kill(62857, SIGUSR1)              = 0
62873 execve("/bin/sh", ["sh", "-c", "killall mpg123"], 0x7ffc8fdf9b98 /* 73 vars */ <unfinished ...>
62873 stat("/home/joao/.nvm/versions/node/v14.18.2/bin/killall", 0x7ffcd521f810) = -1 ENOENT (No such file or directory)
62873 stat("/home/joao/.local/bin/killall", 0x7ffcd521f810) = -1 ENOENT (No such file or directory)
62873 stat("/usr/local/sbin/killall", 0x7ffcd521f810) = -1 ENOENT (No such file or directory)
62873 stat("/usr/local/bin/killall", 0x7ffcd521f810) = -1 ENOENT (No such file or directory)
62873 stat("/usr/sbin/killall", 0x7ffcd521f810) = -1 ENOENT (No such file or directory)
62873 stat("/usr/bin/killall", {st_mode=S_IFREG|0755, st_size=32024, ...}) = 0
62874 execve("/usr/bin/killall", ["killall", "mpg123"], 0x55820e086268 /* 73 vars */) = 0
62874 read(3, "2727 (gsd-rfkill) S 1328 2727 27"..., 1024) = 314
```

4) I grepped for the same syscalls for the executions without soundtrack
```
$ cat syscall_tracer_no_soundtrack.txt | grep clone
62794 clone(child_stack=0x7f4779b1ffb0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[62795], tls=0x7f4779b20700, child_tidptr=0x7f4779b209d0) = 62795

$ cat syscall_tracer_no_soundtrack.txt | grep kill 
62795 kill(62794, SIGUSR1 <unfinished ...>
62795 <... kill resumed>)               = 0
```

As you can see, a lot of syscalls were included to that functionality, including curling a song to play it.
