### PR TITLE
Removing help (h) statement that doesn't work

### DIFF
--- a/src/ttsnake.c
+++ b/src/ttsnake.c
@@ -379,7 +379,7 @@ void showscene (scene_t* scene, int scene_type, int menu) {
 		wprintw(main_window, "\
 		Controls: q: quit | r: restart | WASD/HJKL/ARROWS: move the snake\
 		| +/-: change game speed\n");
-		wprintw(main_window, "          h: help & settings | p: pause game\n");
+		wprintw(main_window, "         | p: pause game\n");
 
 	}
 	else if (game_end) {


### PR DESCRIPTION
The h key already has a function

Fixes #127 .

This PR proposes the following changes:
- Remove the help statement, because the h key already has a function
